### PR TITLE
Makefile & array[10]

### DIFF
--- a/ft_print_combn.c
+++ b/ft_print_combn.c
@@ -79,6 +79,11 @@ void    ft_print_combn(int n)
         int     foc_indx;       /* Witch index of number we focus on */
         int     count;
 
+        if (n <= 0 || n >= 10)  /* checking for valid input 0 < n < 10 */
+        {
+            return;
+        }
+
         foc_indx = (n - 1); /* we focus on the last index of number = unity */
 
         /*

--- a/ft_print_combn.c
+++ b/ft_print_combn.c
@@ -28,7 +28,7 @@ void    ft_print_n_numbers(int* p_tab, int p_foc_indx, int p_nb_indx)
 {
         int     count;
 
-        while (1) 
+        while (1)
         {
             /*
             ** we focus on the index that is not sh last_number
@@ -75,14 +75,14 @@ void    ft_print_n_numbers(int* p_tab, int p_foc_indx, int p_nb_indx)
 
 void    ft_print_combn(int n)
 {
-        int     number[9];      /* Arr that contain all digits of the number */
+        int     number[10];      /* Arr that contain all digits of the number */
         int     foc_indx;       /* Witch index of number we focus on */
         int     count;
 
         foc_indx = (n - 1); /* we focus on the last index of number = unity */
 
         /*
-        ** We initialize our number with 0123456...(n-1) because it can 
+        ** We initialize our number with 0123456...(n-1) because it can
         ** mathematicaly only take this value
         */
         count = 0;

--- a/makefile
+++ b/makefile
@@ -2,12 +2,12 @@
 .SUFFIXES:
 
 ex07: ft_print_combn.o ft_putchar.o main.o
-    gcc ft_print_combn.o ft_putchar.o main.o -o ex07
+	gcc ft_print_combn.o ft_putchar.o main.o -o ex07
 ft_print_combn.o: ft_print_combn.c ft_putchar.h
-    gcc -c ft_print_combn.c
+	gcc -c ft_print_combn.c
 ft_putchar.o: ft_putchar.c
-    gcc -c ft_putchar.c
+	gcc -c ft_putchar.c
 main.o: main.c ft_print_combn.c ft_putchar.h
-    gcc -c main.c
+	gcc -c main.c
 clean:
-    rm -f *.o ex07
+	rm -f *.o ex07


### PR DESCRIPTION
- makefile now indented with tabs instead of spaces (didn't compile)
- array[10] so that n = 9 can works (now only up to 8)

My first contribution ever on Github. I can imagine that the mistakes were added on purpose to slow down copycats.